### PR TITLE
Requires all models to be named

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -10,9 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
       
       - name: Install system dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -8,7 +8,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.CI }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # dreamer 3.1.0.9000
 
+* Remove automatic naming of models, now requires each model to be named (#34).
+
 # dreamer 3.1.0
 
 * Updated README.Rmd and vignettes (#1).

--- a/R/assert.R
+++ b/R/assert.R
@@ -31,3 +31,33 @@ assert_reference_dose <- function(reference_dose) {
     )
   }
 }
+
+assert_model_names <- function(x) {
+  for (i in seq_along(x)) {
+    if (isTRUE(names(x)[i] == "") || is.null(names(x)[i])) {
+      rlang::abort(
+        "All dreamer model arguments must be named in dreamer_mcmc().",
+        class = "dreamer"
+      )
+    }
+  }
+  if (any(duplicated(names(x)))) {
+    rlang::abort("Duplicate model names are not allowed.", class = "dreamer")
+  }
+}
+
+assert_names <- function(x, y, msg) {
+  if (!all(names(x) == names(y))) {
+    stop(msg, call. = FALSE)
+  }
+}
+
+assert_w_prior <- function(w_prior) {
+  w_total <- sum(w_prior)
+  if (!isTRUE(all.equal(w_total, 1))) {
+    stop(
+      "Sum of w_prior for all models must add to 1: ", w_total,
+      call. = FALSE
+    )
+  }
+}

--- a/R/dreamer.R
+++ b/R/dreamer.R
@@ -57,6 +57,7 @@ dreamer_mcmc <- function( #nolint
   load_jags_modules()
   mods <- list(...)
   assert_dreamer_dots(mods)
+  assert_model_names(mods)
   assert_independent_dots(mods)
   all_dots_binary <- assert_binary_dots(mods)
   check_data(data, all_dots_binary)
@@ -67,13 +68,12 @@ dreamer_mcmc <- function( #nolint
     }
   }
   doses <- get_doses(data)
-  all_models <- name_models(mods)
   mcmc_list <- list()
-  for (i in seq_along(all_models)) {
+  for (i in seq_along(mods)) {
     start_time <- Sys.time()
-    mcmc_start_msg(names(all_models)[i], start_time, silent)
+    mcmc_start_msg(names(mods)[i], start_time, silent)
     mcmc_list[[i]] <- fit_model(
-      all_models[[i]],
+      mods[[i]],
       data = data,
       doses = doses,
       n_adapt = n_adapt,
@@ -85,16 +85,16 @@ dreamer_mcmc <- function( #nolint
     end_time <- Sys.time()
     mcmc_end_msg(start_time, end_time, silent)
   }
-  names(mcmc_list) <- names(all_models)
+  names(mcmc_list) <- names(mods)
 
-  w_prior <- get_w_prior(all_models)
+  w_prior <- get_w_prior(mods)
   assert_w_prior(w_prior)
   weight_data <- prep_weight_data(data, all_dots_binary, is_long)
   w <- post_weights(weight_data, mcmc_list, w_prior)
 
   model_index <- get_model_index(mcmc_list, w, n_iter, n_chains)
   times <- if (is_long) sort(unique(data$time)) else NULL
-  model_names <- names(all_models)
+  model_names <- names(mods)
 
   final_output <- c(
     list(
@@ -216,16 +216,6 @@ mcmc_end_msg <- function(start_time, end_time, silent) {
         "total : ", format(round(time_diff, 2), nsmall = 2),
         " ", time_unit, "\n"
       )
-    )
-  }
-}
-
-assert_w_prior <- function(w_prior) {
-  w_total <- sum(w_prior)
-  if (!isTRUE(all.equal(w_total, 1))) {
-    stop(
-      "Sum of w_prior for all models must add to 1: ", w_total,
-      call. = FALSE
     )
   }
 }
@@ -355,22 +345,6 @@ throw_convergence_warn <- function(bad_gelman) {
   }
 }
 
-name_models <- function(model_list) {
-  for (i in seq_along(model_list)) {
-    if (
-      isTRUE(names(model_list)[i] == "") ||
-      is.null(names(model_list)[i]) ||
-      is.na(names(model_list)[i])
-    ) {
-      names(model_list)[i] <- paste0("model_", i, "_", class(model_list[[i]]))
-    }
-  }
-  if (any(duplicated(names(model_list)))) {
-    stop("Duplicate model names are not allowed.", call. = FALSE)
-  }
-  return(model_list)
-}
-
 prep_weight_data <- function(data, binary, is_longitudinal) {
   if (binary) {
     data <- aggregate_binary(data, is_longitudinal)
@@ -393,12 +367,6 @@ dreamer_post_weights <- function(all_mcmc, w_prior, data) {
   w_post <- exp(a_s - (a + log(sum(exp(a_s - a)))))
   names(w_post) <- names(all_mcmc)
   return(list(w_prior = w_prior, w_post = w_post))
-}
-
-assert_names <- function(x, y, msg) {
-  if (!all(names(x) == names(y))) {
-    stop(msg, call. = FALSE)
-  }
 }
 
 check_binary <- function(data) {

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -114,4 +114,7 @@ test_that("assertions", {
   expect_error(assert_doses(NULL), class = "dreamer")
   expect_error(assert_no_dots("foo", foo2 = 5), class = "dreamer")
   expect_error(assert_reference_dose(1:2), class = "dreamer")
+  expect_error(assert_model_names(list(a = 1, 2)), class = "dreamer")
+  expect_error(assert_model_names(list(1, 2)), class = "dreamer")
+  expect_error(assert_model_names(list(a = 1, a = 2)), class = "dreamer")
 })


### PR DESCRIPTION
Fixes the issue in #34.  This will break code which had previously relied on automatic naming of models.