### PR TITLE
Update truncation on exponential dose-response model parameter b_3 

### DIFF
--- a/R/testing_exponential.R
+++ b/R/testing_exponential.R
@@ -1,0 +1,124 @@
+
+library(tidyverse)
+library(DoseFinding)
+
+#exponential example
+test_example <- dreamer_data_independent(
+  n_cohorts = rep(50, 5),
+  doses = c(0, 5, 15, 25, 50),
+  b1 = c(-100, -99, -97, -95, -50),
+  sigma = 50
+)
+
+independent <- dreamer_mcmc(
+  data = test_example,
+  independent = model_independent(
+    mu_b1 = -100,
+    sigma_b1 = 1000,
+    shape = 1,
+    rate = 0.001,
+    w_prior = 1
+  )
+)
+
+plot(independent, data = test_example)
+
+exponential <- dreamer_mcmc(
+  data = test_example,
+  exp = model_exp(
+    mu_b1 = -100,
+    sigma_b1 = 1000,
+    mu_b2 = 0,
+    sigma_b2 = 10,
+    mu_b3 = 0,
+    sigma_b3 = 10,
+    shape = 1,
+    rate = 0.001,
+    w_prior = 1
+  ),
+  n_burn = 1e4,
+  n_iter = 1e4,
+  n_chains = 3
+)
+
+plot(exponential, data = test_example)
+summary(exponential)
+
+#bma example
+bma <- dreamer_mcmc(
+  data = test_example,
+  exp = model_exp(
+    mu_b1 = -100,
+    sigma_b1 = 1000,
+    mu_b2 = 0,
+    sigma_b2 = 10,
+    mu_b3 = 0,
+    sigma_b3 = 1,
+    shape = 1,
+    rate = 0.001,
+    w_prior = 1/3
+  ),
+  linear = model_linear(
+    mu_b1 = -100,
+    sigma_b1 = 1000,
+    mu_b2 = 0,
+    sigma_b2 = 1000,
+    shape = 1,
+    rate = 0.001,
+    w_prior = 1/3
+  ),
+  emax = model_emax(
+    mu_b1 = -100,
+    sigma_b1 = 1000,
+    mu_b2 = 0,
+    sigma_b2 = 1000,
+    mu_b3 = log(15),
+    sigma_b3 = log(15),
+    mu_b4 = 1,
+    sigma_b4 = 2,
+    shape = 1,
+    rate = 0.001,
+    w_prior = 1/3
+  ),
+  
+  n_burn = 1e4,
+  n_iter = 1e4,
+  n_chains = 3
+  
+)
+
+plot(bma, data = test_example)
+plot(bma$exp, data = test_example)
+summary(bma)
+
+# try starting values from dose-finding package
+test_example_df <- dreamer_data_independent(
+  n_cohorts = rep(50, 5),
+  doses = c(0, 5, 15, 25, 50),
+  b1 = c(-100, -99, -97, -95, -50),
+  sigma = 50
+)
+
+df <- fitMod(dose = test_example_df$dose, resp = test_example_df$response, model = "exponential")
+delta_start <- -1/df$coefs[3]
+
+exponential <- dreamer_mcmc(
+  data = test_example_df,
+  exp = model_exp(
+    mu_b1 = -100,
+    sigma_b1 = 1000,
+    mu_b2 = 0,
+    sigma_b2 = 10,
+    mu_b3 = delta_start,
+    sigma_b3 = 1,
+    shape = 1,
+    rate = 0.001,
+    w_prior = 1
+  ),
+  n_burn = 1e4,
+  n_iter = 1e4,
+  n_chains = 3
+)
+
+plot(exponential, data = test_example_df)
+summary(exponential)

--- a/inst/jags/prior_exp.jags
+++ b/inst/jags/prior_exp.jags
@@ -5,4 +5,4 @@ tau2_b2 <- 1 / sigma_b2^2
 tau2_b3 <- 1 / sigma_b3^2
 b1 ~ dnorm(mu_b1, tau2_b1)
 b2 ~ dnorm(mu_b2, tau2_b2)
-b3 ~ dnorm(mu_b3, tau2_b3) T(, 0)
+b3 ~ dnorm(mu_b3, tau2_b3) T(-10, 0)

--- a/inst/jags/prior_exp.jags
+++ b/inst/jags/prior_exp.jags
@@ -5,4 +5,4 @@ tau2_b2 <- 1 / sigma_b2^2
 tau2_b3 <- 1 / sigma_b3^2
 b1 ~ dnorm(mu_b1, tau2_b1)
 b2 ~ dnorm(mu_b2, tau2_b2)
-b3 ~ dnorm(mu_b3, tau2_b3) T(0, )
+b3 ~ dnorm(mu_b3, tau2_b3) T(, 0)

--- a/inst/jags/prior_exp_binary.jags
+++ b/inst/jags/prior_exp_binary.jags
@@ -3,4 +3,4 @@ tau2_b2 <- 1 / sigma_b2^2
 tau2_b3 <- 1 / sigma_b3^2
 b1 ~ dnorm(mu_b1, tau2_b1)
 b2 ~ dnorm(mu_b2, tau2_b2)
-b3 ~ dnorm(mu_b3, tau2_b3) T(0, )
+b3 ~ dnorm(mu_b3, tau2_b3) T(-10, 0)


### PR DESCRIPTION
@rich-payne - I updated the prior for b_3 in the exponential model to be truncated in the proper direction for continuous data.  I also explored this issue more fully and this is what I found:

- We can change this to use the same parameterization as the DoseFinding package.  I didn't do that because of other unresolved issues.  Leaving it like this is fine with me though.
- There is a JAGS error that pops up whenever the sampler would estimate the exponential to be 0.  This is dependent on the maximum dose in the study.  You can calculate what this is based on the candidate dose range and truncate the prior with this value - I did this and it eliminated the error.
- Another way to do this is to just control it with the prior sd for that parameter.  For those values which cause the error, it is quite extreme and far from where it should be sampling - a reasonable prior on that parameter took care of it for all of the simulations that I looked at.  Using a starting value from the maximum likelihood estimate did not fix the issue.  So the options would be: 
- let it error out and put a warning message to check the prior
- update the truncation on the prior based on the inputted candidate dose range
- something else?

Overall this is a finicky model - but from my exploration the BMA does a good job adapting away from it when it is not appropriate (when it is generally not fitting the data well) - as long as there is a suitable alternative.  

See R/testing_exponential.R for some example code for exponential models (and the correspond DoseFinding model).  